### PR TITLE
examples/double-talk-aec.html の AudioContext に sampleRate パラメータを指定する

### DIFF
--- a/examples/double-talk-aec.html
+++ b/examples/double-talk-aec.html
@@ -79,7 +79,10 @@
           const dtlnAec = await Shiguredo.DtlnAec.loadModel("../dist/", { modelName });
 
           // スピーカ音源を再生
-          audioContext = new AudioContext();
+          //
+          // breizhn/DTLN-aec は入力として 16kHz を想定しているので、
+          // 常に 16kHz になるように sampleRate 引数を指定しておく
+          audioContext = new AudioContext({sampleRate: 16000});
           const outputAudio = new Audio(document.getElementById("audio-file").value);
           outputAudio.loop = true;
 


### PR DESCRIPTION
Discord の #media-processors チャンネルでの @enm10k さんからの[フィードバック](https://discord.com/channels/501033497255870474/886571423089455155/978130904297926756)の反映です。
examples/double-talk-aec.html で入力ファイルを読み込んでスピーカー出力する際に、環境によってはサンプリングレートが 44.1 kHz になることがあり、エラーとなっていたので、常にサンプリングレートが 16 kHz となるように `AudioContext` 初期化時のパラメータを追加しました。
（dtln-aec は 48kHz ないし 16kHz の音声を扱うことができて、かつ、前者は後者に内部でリサンプリングされるので、最初から 16kHz になっているのが一番効率が良い）
